### PR TITLE
[irods/irods#6437] Add support for new platforms (main)

### DIFF
--- a/irods_consortium_continuous_integration_build_hook.py
+++ b/irods_consortium_continuous_integration_build_hook.py
@@ -14,7 +14,7 @@ def add_cmake_to_front_of_path():
 
 def install_building_dependencies(externals_directory):
     externals_list = [
-        'irods-externals-avro1.11.0-0',
+        'irods-externals-avro1.11.0-1',
         'irods-externals-boost1.78.0-0',
         'irods-externals-clang-runtime13.0.0-0',
         'irods-externals-clang13.0.0-0',
@@ -41,13 +41,15 @@ def install_os_specific_dependencies_apt():
     irods_python_ci_utilities.install_os_packages(['make', 'gcc'])
 
 def install_os_specific_dependencies_yum():
-    irods_python_ci_utilities.install_os_packages(['curl-devel', 'openssl-devel'])
+    irods_python_ci_utilities.install_os_packages(['make', 'gcc', 'curl-devel', 'openssl-devel'])
 
 def install_os_specific_dependencies():
     dispatch_map = {
         'Ubuntu': install_os_specific_dependencies_apt,
+        'Debian gnu_linux': install_os_specific_dependencies_apt,
         'Centos': install_os_specific_dependencies_yum,
         'Centos linux': install_os_specific_dependencies_yum,
+        'Almalinux': install_os_specific_dependencies_yum,
         'Opensuse ': install_os_specific_dependencies_yum,
     }
     try:


### PR DESCRIPTION
Bumped avro version as it was not the right revision.

Installing make and gcc as almalinux:8 did not seem to have them in the
base image.