### PR TITLE
Plugin does not crash agent on unsupported rule text (4-2-stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,10 +68,6 @@ install(FILES ${CMAKE_SOURCE_DIR}/packaging/test_rule_engine_plugin_logical_quot
         DESTINATION ${IRODS_HOME_DIRECTORY}/scripts/irods/test
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 
-install(FILES ${CMAKE_SOURCE_DIR}/packaging/run_logical_quotas_test.py
-        DESTINATION ${IRODS_HOME_DIRECTORY}/scripts
-        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
-
 set(PLUGIN_PACKAGE_NAME irods-rule-engine-plugin-logical-quotas)
 
 set(CPACK_PACKAGE_VERSION ${IRODS_PLUGIN_VERSION})

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -12,5 +12,4 @@ chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scrip
 chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/irods
 chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/irods/test
 chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/irods/test/test_rule_engine_plugin_logical_quotas.py
-chown $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/scripts/run_logical_quotas_test.py
 

--- a/packaging/run_logical_quotas_test.py
+++ b/packaging/run_logical_quotas_test.py
@@ -1,5 +1,0 @@
-import subprocess
-
-if __name__ == "__main__":
-    subprocess.call(['sudo', 'python', '-m', 'xmlrunner', 'irods.test.test_rule_engine_plugin_update_collection_mtime'])
-

--- a/packaging/test_rule_engine_plugin_logical_quotas.py
+++ b/packaging/test_rule_engine_plugin_logical_quotas.py
@@ -5,6 +5,7 @@ import sys
 import shutil
 import json
 import subprocess
+import textwrap
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -784,6 +785,44 @@ class Test_Rule_Engine_Plugin_Logical_Quotas(session.make_sessions_mixin(admins,
                 contents = 'it worked!'
                 self.user.assert_icommand(['istream', 'write', 'foo'], input=contents)
                 self.assert_quotas(col, expected_number_of_objects=1, expected_size_in_bytes=len(contents))
+
+    @unittest.skipIf(test.settings.RUN_IN_TOPOLOGY, "Skip for Topology Testing")
+    def test_plugin_does_not_crash_on_unsupported_rule_text_executed_via_irule_F__issue_6831(self):
+        config = IrodsConfig()
+
+        with lib.file_backed_up(config.server_config_path):
+            with lib.file_backed_up(config.client_environment_path):
+                self.enable_rule_engine_plugin(config)
+
+                # Create a rule file that contains rule code that isn't supported by the plugin.
+                # This originally caused the plugin to throw an exception which lead to the agent
+                # crashing.
+                rule_file = os.path.join(self.user.local_session_dir, 'issue_6831.r')
+                with open(rule_file, 'w') as f:
+                    f.write(textwrap.dedent('''
+                    def syntax_not_supported_by_logical_quotas(rule_args, callback, rei):
+                        callback.writeLine('serverLog', 'some data')
+
+                    INPUT null
+                    OUTPUT null
+                    '''))
+
+                # Show that the plugin gracefully handles unsupported rule code.
+                # The use of "-F" is important because it tests the code path that originally
+                # caused an exception to be thrown.
+                self.user.assert_icommand(['irule', '-F', rule_file])
+
+                # Show that the plugin is still working.
+                col = self.user.session_collection
+                self.logical_quotas_start_monitoring_collection(col)
+
+                # Show that the REP hasn't detected any data objects in the monitored collection.
+                self.assert_quotas(col, expected_number_of_objects=0, expected_size_in_bytes=0)
+
+                # Show that after creating a new data object via itouch, the REP correctly increments
+                # the data object count by one.
+                self.user.assert_icommand(['itouch', 'foo'])
+                self.assert_quotas(col, expected_number_of_objects=1, expected_size_in_bytes=0)
 
     #
     # Utility Functions

--- a/packaging/test_rule_engine_plugin_logical_quotas.py
+++ b/packaging/test_rule_engine_plugin_logical_quotas.py
@@ -758,7 +758,7 @@ class Test_Rule_Engine_Plugin_Logical_Quotas(session.make_sessions_mixin(admins,
                 # Show that the REP hasn't detected any data objects in the monitored collection.
                 self.assert_quotas(col, expected_number_of_objects=0, expected_size_in_bytes=0)
 
-                # Show that after creating a new data object via itouch, the REP correctly in increments
+                # Show that after creating a new data object via itouch, the REP correctly increments
                 # the data object count by one.
                 self.user.assert_icommand(['itouch', 'foo'])
                 self.assert_quotas(col, expected_number_of_objects=1, expected_size_in_bytes=0)


### PR DESCRIPTION
Cannot provide a test without introducing a dependency on the PREP. Introducing a dependency for running the tests doesn't seem bad, we just need to make the iRODS test hook install it.

Verified at the bench that the issue is resolved with this change.

All tests pass at the bench.