### PR TITLE
[#128] Enforce quota limits for touch API PEPs (4-3-stable)

### DIFF
--- a/src/handler.hpp
+++ b/src/handler.hpp
@@ -301,6 +301,7 @@ namespace irods::handler
 	  private:
 		inline static std::string path_;
 		inline static bool exists_ = false;
+		inline static bool update_count_ = false;
 	}; // class pep_api_touch
 } // namespace irods::handler
 


### PR DESCRIPTION
Ported from #129.

All tests pass against iRODS 4.3.4.

This work may result in a branch for iRODS 4.3.3.