### PR TITLE
[irods/irods#8454] Only use new `query_type` for 5.1

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -604,7 +604,7 @@ namespace irods::handler
 
 			std::vector args{path + '%'};
 			auto query = irods::experimental::query_builder{}
-#if IRODS_VERSION_INTEGER < 5000002
+#if IRODS_VERSION_INTEGER < 5000090
 			                 .type(irods::experimental::query_type::specific)
 #else
 			                 .type(irods::query_type::specific)
@@ -647,7 +647,7 @@ namespace irods::handler
 
 			std::vector args{path + '%'};
 			auto query = irods::experimental::query_builder{}
-#if IRODS_VERSION_INTEGER < 5000002
+#if IRODS_VERSION_INTEGER < 5000090
 			                 .type(irods::experimental::query_type::specific)
 #else
 			                 .type(irods::query_type::specific)


### PR DESCRIPTION
In service of irods/irods#8454

Part of the alternate approach for fmtlib 10+ support for 5.0.2
Companion to irods/irods#8579